### PR TITLE
Remove Transfer-Encoding for empty body response per RFC 9112 sec 6.3

### DIFF
--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -366,8 +366,8 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
 
         if self.status in (204, 304) or 100 >= self.status < 200:
             #
-            # Remove transfer-encoding since there is no body
-            # and this can confuse some clients (e.g. older aiohttp)
+            # Remove transfer-encoding/content-length since there is no
+            # body and this can confuse some clients (e.g. older aiohttp)
             #
             # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
             #

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -364,7 +364,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         if self._compression:
             await self._start_compression(request)
 
-        if self.status in (204, 304) or 100 >= self.status < 200:
+        if self.status in (204, 304) or 100 <= self.status < 200:
             #
             # Remove transfer-encoding/content-length since there is no
             # body and this can confuse some clients (e.g. older aiohttp)

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -380,14 +380,8 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             #
             if hdrs.TRANSFER_ENCODING in headers:
                 del headers[hdrs.TRANSFER_ENCODING]
-            # HTTP 1.0: https://tools.ietf.org/html/rfc1945#section-10.4
-            # 0 is not a valid value for Content-Length header for HTTP/1.0
             if hdrs.CONTENT_LENGTH in headers:
                 del headers[hdrs.CONTENT_LENGTH]
-            # HTTP 1.1: https://tools.ietf.org/html/rfc7230#section-3.3.2
-            # 0 is a valid value for Content-Length header for HTTP/1.1
-            if version >= HttpVersion11:
-                headers[hdrs.CONTENT_LENGTH] = "0"
         elif self._chunked:
             if version != HttpVersion11:
                 raise RuntimeError(

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -638,7 +638,7 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     resp = Response(status=status)
     resp.enable_chunked_encoding()
     await resp.prepare(req)
-    assert resp.content_length == "0"
+    assert resp.content_length is None
     assert not resp.chunked
 
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -642,24 +642,6 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     assert not resp.chunked
 
 
-@pytest.mark.parametrize("status", (100, 101, 204, 304))
-async def test_rm_transfer_encoding_rfc_9112_6_3_http_10(status: int) -> None:
-    """Remove transfer encoding for RFC 9112 sec 6.3 with HTTP/1.0."""
-    writer = mock.Mock()
-
-    async def write_headers(status_line, headers):
-        assert hdrs.CONTENT_LENGTH not in headers
-        assert hdrs.TRANSFER_ENCODING not in headers
-
-    writer.write_headers.side_effect = write_headers
-    req = make_request("GET", "/", version=HttpVersion10, writer=writer)
-    resp = Response(status=status)
-    resp.enable_chunked_encoding()
-    await resp.prepare(req)
-    assert resp.content_length is None
-    assert not resp.chunked
-
-
 async def test_content_length_on_chunked() -> None:
     req = make_request("GET", "/")
     resp = Response(body=b"answer")

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -624,6 +624,22 @@ async def test_rm_content_length_if_compression_http10() -> None:
     assert resp.content_length is None
 
 
+async def test_rm_transfer_encoding_rfc_9112_6_3() -> None:
+    """Remove transfer encoding for RFC 9112 sec 6.3."""
+    writer = mock.Mock()
+
+    async def write_headers(status_line, headers):
+        assert hdrs.CONTENT_LENGTH not in headers
+        assert hdrs.TRANSFER_ENCODING not in headers
+
+    writer.write_headers.side_effect = write_headers
+    req = make_request("GET", "/", version=HttpVersion11, writer=writer)
+    resp = Response(body=BytesPayload(b"answer"))
+    resp.enable_compression(ContentCoding.gzip)
+    await resp.prepare(req)
+    assert resp.content_length is None
+
+
 async def test_content_length_on_chunked() -> None:
     req = make_request("GET", "/")
     resp = Response(body=b"answer")

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -635,8 +635,7 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
 
     writer.write_headers.side_effect = write_headers
     req = make_request("GET", "/", version=HttpVersion11, writer=writer)
-    resp = Response(status=status)
-    resp.enable_chunked_encoding()
+    resp = Response(status=status, headers={hdrs.TRANSFER_ENCODING: "chunked"})
     await resp.prepare(req)
     assert resp.content_length is None
     assert not resp.chunked

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -637,7 +637,7 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     req = make_request("GET", "/", version=HttpVersion11, writer=writer)
     resp = Response(status=status, headers={hdrs.TRANSFER_ENCODING: "chunked"})
     await resp.prepare(req)
-    assert resp.content_length is None
+    assert resp.content_length == 0
     assert not resp.chunked
 
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -652,7 +652,7 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_10(status: int) -> None:
         assert hdrs.TRANSFER_ENCODING not in headers
 
     writer.write_headers.side_effect = write_headers
-    req = make_request("GET", "/", version=HttpVersion11, writer=writer)
+    req = make_request("GET", "/", version=HttpVersion10, writer=writer)
     resp = Response(status=status)
     resp.enable_chunked_encoding()
     await resp.prepare(req)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -630,7 +630,7 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     writer = mock.Mock()
 
     async def write_headers(status_line, headers):
-        assert headers[hdrs.CONTENT_LENGTH] == "0"
+        assert hdrs.CONTENT_LENGTH not in headers
         assert hdrs.TRANSFER_ENCODING not in headers
 
     writer.write_headers.side_effect = write_headers


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix compliance with https://datatracker.ietf.org/doc/html/rfc9112#section-6.3

## Are there changes in behavior for the user?

`Transfer-Encoding` and `Content-Length` will be removed from the server response when sending a 1xx (Informational), 204 (No Content), or 304 (Not Modified) status since no body is expected for these status codes

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
