### PR TITLE
Fix py parser not treating 204/304/1xx as an empty body

### DIFF
--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -338,13 +338,14 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         self._upgraded = msg.upgrade
 
                         method = getattr(msg, "method", self.method)
+                        code = getattr(msg, "code", 100)
 
                         assert self.protocol is not None
                         # calculate payload
                         # 204, 304, 1xx should not have a body per
                         # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
-                        code_indicates_empty_body = self.code in (204, 304) or (
-                            self.code and 100 <= self.code < 200
+                        code_indicates_empty_body = (
+                            code in (204, 304) or 100 <= code < 200
                         )
                         if (
                             (length is not None and length > 0)

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -338,7 +338,8 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         self._upgraded = msg.upgrade
 
                         method = getattr(msg, "method", self.method)
-                        code = getattr(msg, "code", 100)
+                        # code is only present on responses
+                        code = getattr(msg, "code", 0)
 
                         assert self.protocol is not None
                         # calculate payload

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -731,7 +731,7 @@ class HttpPayloadParser:
             real_payload = payload
 
         # payload parser
-        if not response_with_body or code in (204, 304) or 100 <= code < 200:
+        if not response_with_body or code in (204, 304) or (code and 100 <= code < 200):
             # don't parse payload if it's not expected to be received
             # 204, 304, 1xx should not have a body per
             # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -731,7 +731,7 @@ class HttpPayloadParser:
             real_payload = payload
 
         # payload parser
-        if not response_with_body:
+        if not response_with_body or code in (204, 304) or 100 <= code < 200:
             # don't parse payload if it's not expected to be received
             self._type = ParseState.PARSE_NONE
             real_payload.feed_eof()

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -388,34 +388,33 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                                 auto_decompress=self._auto_decompress,
                                 lax=self.lax,
                             )
+                        elif (
+                            not code_indicates_empty_body
+                            and length is None
+                            and self.read_until_eof
+                        ):
+                            payload = StreamReader(
+                                self.protocol,
+                                timer=self.timer,
+                                loop=loop,
+                                limit=self._limit,
+                            )
+                            payload_parser = HttpPayloadParser(
+                                payload,
+                                length=length,
+                                chunked=msg.chunked,
+                                method=method,
+                                compression=msg.compression,
+                                code=self.code,
+                                readall=True,
+                                response_with_body=self.response_with_body,
+                                auto_decompress=self._auto_decompress,
+                                lax=self.lax,
+                            )
+                            if not payload_parser.done:
+                                self._payload_parser = payload_parser
                         else:
-                            if (
-                                not code_indicates_empty_body
-                                and length is None
-                                and self.read_until_eof
-                            ):
-                                payload = StreamReader(
-                                    self.protocol,
-                                    timer=self.timer,
-                                    loop=loop,
-                                    limit=self._limit,
-                                )
-                                payload_parser = HttpPayloadParser(
-                                    payload,
-                                    length=length,
-                                    chunked=msg.chunked,
-                                    method=method,
-                                    compression=msg.compression,
-                                    code=self.code,
-                                    readall=True,
-                                    response_with_body=self.response_with_body,
-                                    auto_decompress=self._auto_decompress,
-                                    lax=self.lax,
-                                )
-                                if not payload_parser.done:
-                                    self._payload_parser = payload_parser
-                            else:
-                                payload = EMPTY_PAYLOAD
+                            payload = EMPTY_PAYLOAD
 
                         messages.append((msg, payload))
                 else:

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -733,6 +733,8 @@ class HttpPayloadParser:
         # payload parser
         if not response_with_body or code in (204, 304) or 100 <= code < 200:
             # don't parse payload if it's not expected to be received
+            # 204, 304, 1xx should not have a body per
+            # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
             self._type = ParseState.PARSE_NONE
             real_payload.feed_eof()
             self.done = True

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -19,6 +19,7 @@ from aiohttp.http_parser import (
     HttpPayloadParser,
     HttpRequestParserPy,
     HttpResponseParserPy,
+    HttpVersion,
 )
 
 try:
@@ -1058,6 +1059,132 @@ def test_parse_no_length_payload(parser: Any) -> None:
     text = b"PUT / HTTP/1.1\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
     assert payload.is_eof()
+
+
+def test_parse_content_length_payload_multiple(response: Any) -> None:
+    text = b"HTTP/1.1 200 OK\r\n" b"content-length: 5\r\n\r\n" b"first"
+    msg, payload = response.feed_data(text)[0][0]
+    assert msg.version == HttpVersion(major=1, minor=1)
+    assert msg.code == 200
+    assert msg.reason == "OK"
+    assert msg.headers == CIMultiDict(
+        [
+            ("Content-Length", "5"),
+        ]
+    )
+    assert msg.raw_headers == ((b"content-length", b"5"),)
+    assert not msg.should_close
+    assert msg.compression is None
+    assert not msg.upgrade
+    assert not msg.chunked
+    assert payload.is_eof()
+    assert b"first" == b"".join(d for d in payload._buffer)
+
+    text = b"HTTP/1.1 200 OK\r\n" b"content-length: 6\r\n\r\n" b"second"
+    msg, payload = response.feed_data(text)[0][0]
+    assert msg.version == HttpVersion(major=1, minor=1)
+    assert msg.code == 200
+    assert msg.reason == "OK"
+    assert msg.headers == CIMultiDict(
+        [
+            ("Content-Length", "6"),
+        ]
+    )
+    assert msg.raw_headers == ((b"content-length", b"6"),)
+    assert not msg.should_close
+    assert msg.compression is None
+    assert not msg.upgrade
+    assert not msg.chunked
+    assert payload.is_eof()
+    assert b"second" == b"".join(d for d in payload._buffer)
+
+
+def test_parse_content_length_than_chunked_payload(response: Any) -> None:
+    text = b"HTTP/1.1 200 OK\r\n" b"content-length: 5\r\n\r\n" b"first"
+    msg, payload = response.feed_data(text)[0][0]
+    assert msg.version == HttpVersion(major=1, minor=1)
+    assert msg.code == 200
+    assert msg.reason == "OK"
+    assert msg.headers == CIMultiDict(
+        [
+            ("Content-Length", "5"),
+        ]
+    )
+    assert msg.raw_headers == ((b"content-length", b"5"),)
+    assert not msg.should_close
+    assert msg.compression is None
+    assert not msg.upgrade
+    assert not msg.chunked
+    assert payload.is_eof()
+    assert b"first" == b"".join(d for d in payload._buffer)
+
+    text = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"transfer-encoding: chunked\r\n\r\n"
+        b"6\r\nsecond\r\n0\r\n\r\n"
+    )
+    msg, payload = response.feed_data(text)[0][0]
+    assert msg.version == HttpVersion(major=1, minor=1)
+    assert msg.code == 200
+    assert msg.reason == "OK"
+    assert msg.headers == CIMultiDict(
+        [
+            ("Transfer-Encoding", "chunked"),
+        ]
+    )
+    assert msg.raw_headers == ((b"transfer-encoding", b"chunked"),)
+    assert not msg.should_close
+    assert msg.compression is None
+    assert not msg.upgrade
+    assert msg.chunked
+    assert payload.is_eof()
+    assert b"second" == b"".join(d for d in payload._buffer)
+
+
+@pytest.mark.parametrize("code", [204, 304])
+def test_parse_chunked_payload_empty_body_than_another_chunked(
+    response: Any, code: int
+) -> None:
+    head = f"HTTP/1.1 {code} OK\r\n".encode()
+    text = head + b"transfer-encoding: chunked\r\n\r\n"
+    msg, payload = response.feed_data(text)[0][0]
+    assert msg.version == HttpVersion(major=1, minor=1)
+    assert msg.code == code
+    assert msg.reason == "OK"
+    assert msg.headers == CIMultiDict(
+        [
+            ("Transfer-Encoding", "chunked"),
+        ]
+    )
+    assert msg.raw_headers == ((b"transfer-encoding", b"chunked"),)
+    assert not msg.should_close
+    assert msg.compression is None
+    assert not msg.upgrade
+    assert msg.chunked
+    assert payload.is_eof()
+    assert b"" == b"".join(d for d in payload._buffer)
+
+    text = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"transfer-encoding: chunked\r\n\r\n"
+        b"6\r\nsecond\r\n0\r\n\r\n"
+    )
+    msg, payload = response.feed_data(text)[0][0]
+    assert msg.version == HttpVersion(major=1, minor=1)
+    assert msg.code == 200
+    assert msg.reason == "OK"
+    assert msg.headers == CIMultiDict(
+        [
+            ("Transfer-Encoding", "chunked"),
+        ]
+    )
+    assert msg.raw_headers == ((b"transfer-encoding", b"chunked"),)
+    assert not msg.should_close
+    assert msg.compression is None
+    assert not msg.upgrade
+    assert msg.chunked
+    assert payload.is_eof()
+    assert b"second" == b"".join(d for d in payload._buffer)
 
 
 def test_partial_url(parser: Any) -> None:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1141,7 +1141,7 @@ def test_parse_content_length_than_chunked_payload(response: Any) -> None:
     assert b"second" == b"".join(d for d in payload._buffer)
 
 
-@pytest.mark.parametrize("code", [204, 304])
+@pytest.mark.parametrize("code", [204, 304, 101, 102])
 def test_parse_chunked_payload_empty_body_than_another_chunked(
     response: Any, code: int
 ) -> None:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1162,7 +1162,7 @@ def test_parse_chunked_payload_empty_body_than_another_chunked(
     assert not msg.upgrade
     assert msg.chunked
     assert payload.is_eof()
-    assert b"" == b"".join(d for d in payload._buffer)
+    assert not hasattr(payload, "_buffer")
 
     text = (
         b"HTTP/1.1 200 OK\r\n"


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

204/304/1xx are now always treated as an empty body in the py parser to match the c parser and comply with https://datatracker.ietf.org/doc/html/rfc9112#section-6.3

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
